### PR TITLE
fix IndexError

### DIFF
--- a/astroalign.py
+++ b/astroalign.py
@@ -551,7 +551,7 @@ def _ransac(data, model, thresh, min_matches):
         maybe_idxs = all_idxs[iter_i : iter_i + 1]
         test_idxs = list(all_idxs[:iter_i])
         test_idxs.extend(list(all_idxs[iter_i + 1 :]))
-        test_idxs = _np.array(test_idxs)
+        test_idxs = _np.array(test_idxs).astype(int)
         maybeinliers = data[maybe_idxs, :]
         test_points = data[test_idxs, :]
         maybemodel = model.fit(maybeinliers)


### PR DESCRIPTION
Calling `find_transform` sometimes yields an unexpected `IndexError: arrays used as indices must be of integer (or boolean) type` on line 556 `test_points = data[test_idxs, :]`. To resolve the IndexError, I cast `test_idxs` using `.astype(int)` on line 554.

Among the cases I have tested, the cases that would have yielded IndexError now yield MaxIterError (List of matching triangles exhausted before an acceptable transformation was found) after my fix. Regardless, resolving the unexpected IndexError would make debugging much more user-friendly.

Below is a program that would have yielded IndexError.
```
import astroalign as aa

source = [(1, 2), (3, 4), (5, 6), (8, 9)]
target = [(2, 2), (4, 4), (6, 6), (10, 9)]
transf, (source_list, target_list) = aa.find_transform(source, target)
```