### PR TITLE
add: bottleneck support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+dist/
+astroalign.egg-info/

--- a/README.md
+++ b/README.md
@@ -29,30 +29,50 @@ You can find a Jupyter notebook example with the main features at [http://quatro
 
 **Full documentation:** https://astroalign.readthedocs.io/
 
-***
-
-## Installation
+# Installation
 
 Using setuptools:
 
-    $ pip install astroalign
+```bash
+$ pip install astroalign
+```
 
 or from this distribution with
 
-    $ python setup.py install
+```bash
+$ python setup.py install
+```
 
-***
+## Performance: Optional
 
-## Usage example
+This library is optionally compatible with [bottleneck](https://github.com/pydata/bottleneck) and will offer performance improvements in most cases. Install bottleneck in your project as a peer to astroalign using:
 
-    >>> import astroalign as aa
-    >>> aligned_image, footprint = aa.register(source_image, target_image)
+```bash
+pip install bottleneck
+```
+
+`Astroalign` will pick this optional dependency up and use it's performance improved functions for computing transforms.
+
+## Running Tests
+
+```bash
+python tests/test_align.py
+```
+
+# Usage example
+
+```
+>>> import astroalign as aa
+>>> aligned_image, footprint = aa.register(source_image, target_image)
+```
 
 In this example `source_image` will be interpolated by a transformation to coincide pixel to pixel with `target_image` and stored in `aligned_image`.
 
 If we are only interested in knowing the transformation and the correspondence of control points in both images, use `find_transform` will return the transformation in a [Scikit-Image](https://scikit-image.org/) `SimilarityTransform` object and a list of stars in source with the corresponding stars in target.
 
-    >>> transf, (s_list, t_list) = aa.find_transform(source, target)
+```
+>>> transf, (s_list, t_list) = aa.find_transform(source, target)
+```
 
 `source` and `target` can each either be the numpy array of the image (grayscale or color),
 or an iterable of (x, y) pairs of star positions on the image.
@@ -61,9 +81,7 @@ The returned `transf` object is a scikit-image [`SimilarityTranform`](http://sci
 
 `s_list` and `t_list` are numpy arrays of (x, y) point correspondence between `source` and `target`. `transf` applied to `s_list` will approximately render `t_list`.
 
-***
-
-## Citation
+# Citation
 
 If you use astroalign in a scientific publication, we would appreciate citations to the following [paper](https://www.sciencedirect.com/science/article/pii/S221313372030038X):
 

--- a/astroalign.py
+++ b/astroalign.py
@@ -57,6 +57,12 @@ __all__ = [
     "register",
 ]
 
+try:
+    import bottleneck as bn
+except ImportError:
+    HAS_BOTTLENECK = False
+else:
+    HAS_BOTTLENECK = True
 
 import numpy as _np
 from skimage.transform import estimate_transform
@@ -81,6 +87,26 @@ The number of nearest neighbors of a given star (including itself) to construct
 the triangle invariants.
 
 Default: 5
+"""
+
+_default_median = bn.nanmedian if HAS_BOTTLENECK else _np.nanmedian # pragma: no cover
+"""
+Default median function when/if optional bottleneck is available
+"""
+
+_default_average = bn.nanmean if HAS_BOTTLENECK else _np.nanmean # pragma: no cover
+"""
+Default mean function when/if optional bottleneck is available
+"""
+
+_default_sum = bn.nansum if HAS_BOTTLENECK else _np.nansum # pragma: no cover
+"""
+Default sum function when/if optional bottleneck is available
+"""
+
+_default_std = bn.nanstd if HAS_BOTTLENECK else _np.nanstd # pragma: no cover
+"""
+Default std deviation function when/if optional bottleneck is available
 """
 
 
@@ -208,7 +234,7 @@ def _bw(image):
     "Return a 2D numpy array for an array of arbitrary channels"
     if image.ndim == 2:
         return image
-    return _np.mean(image, axis=-1)
+    return _default_average(image, axis=-1)
 
 
 def _shape(image):
@@ -395,7 +421,7 @@ def apply_transform(
         output_shape=target_shape,
         order=3,
         mode="constant",
-        cval=_np.median(source_data),
+        cval=_default_median(source_data),
         clip=True,
         preserve_range=True,
     )
@@ -478,7 +504,7 @@ def _find_sources(img, detection_sigma=5, min_area=5):
     import sep
 
     if isinstance(img, _np.ma.MaskedArray):
-        image = img.filled(fill_value=_np.median(img)).astype("float32")
+        image = img.filled(fill_value=_default_median(img)).astype("float32")
     else:
         image = img.astype("float32")
     bkg = sep.Background(image)


### PR DESCRIPTION
Recently I have been working on a project that uses `astroalign`, `ccdproc` and `astropy`. In the former two I had discovered that [bottleneck](https://bottleneck.readthedocs.io/) was an easy drop in replacement for some numpy functions and had impressive results. I had been wondering if astroalign could benefit from the same and turns out it easily can, so that's what I started here.

What do you think?

In the process I found it a little hard to work with the repo and know what dependencies if needed and since I am using pipenv and pyenv I thought it would be helpful to add support for pip dependencies and virtual environments.

This PR is a WIP but I wanted to get it raised ASAP for feedback and see if there was an appetite for this and what I might be missing in order to get it merged for others.