### PR TITLE
Don't install ez_setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ def run():
         author="Martin Beroiz",
         author_email="martinberoiz@gmail.com",
         url="https://astroalign.readthedocs.io/",
-        py_modules=["astroalign", "ez_setup"],
+        py_modules=["astroalign"],
         install_requires=REQUIREMENTS,
         test_suite="tests",
     )


### PR DESCRIPTION
Hi,

I am [maintaining the astroalign package in Debian](https://tracker.debian.org/pkg/astroalign).

Installing ez_setup may clash with the ez_setup package itself, or with other packages which accidently do the same. And it is not needed anyway to run astroalign. This clash was reported as [Debian#1018791](https://bugs.debian.org/1018791) and is now locally fixed in the Debian package. It may however be useful to do the same here.

Best

Ole