### PR TITLE
No matches to compare bug

### DIFF
--- a/astroalign.py
+++ b/astroalign.py
@@ -608,7 +608,7 @@ def _ransac(data, model, thresh, min_matches):
         maybe_idxs = all_idxs[iter_i : iter_i + 1]
         test_idxs = list(all_idxs[:iter_i])
         test_idxs.extend(list(all_idxs[iter_i + 1 :]))
-        test_idxs = _np.array(test_idxs)
+        test_idxs = _np.array(test_idxs, dtype="i8")
         maybeinliers = data[maybe_idxs, :]
         test_points = data[test_idxs, :]
         maybemodel = model.fit(maybeinliers)

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -631,6 +631,13 @@ class TestFewSources(unittest.TestCase):
     def test_register_sixsources(self):
         self.check_if_register_ok(6)
 
+    def test_three_match_one_off(self):
+        "Test corner case with 1 triangle match + unmatched extra star"
+        source = [(1, 2), (3, 4), (5, 6), (8, 9)]
+        target = [(2, 2), (4, 4), (6, 6), (15, 9)]
+        with self.assertRaises(aa.MaxIterError):
+            aa.find_transform(source, target)
+
 
 class TestColorImages(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes a corner case where there is only one triangle match and no other triangles to test against.
