### PR TITLE
Changing sep for sep-pjw

### DIFF
--- a/.github/workflows/aa-ci.yml
+++ b/.github/workflows/aa-ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@main

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install coverage
         run: pip install coverage
       - name: Install astroalign dependencies
-        run: pip install "numpy>=1.11" "scipy>=0.15" scikit-image sep
+        run: pip install "numpy>=1.11" "scipy>=0.15" scikit-image sep-pjw
       - name: Install test dependencies
         run: pip install -r tests/requirements.txt
       - name: Run coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@main
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - name: Install coverage
         run: pip install coverage
       - name: Install astroalign dependencies

--- a/astroalign.py
+++ b/astroalign.py
@@ -561,7 +561,7 @@ def register(
 
 def _find_sources(img, detection_sigma=5, min_area=5, mask=None):
     """Return sources (x, y) sorted by brightness."""
-    import sep
+    import sep_pjw as sep
 
     image = img.astype("float32")
     bkg = sep.Background(image, mask=mask)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ maintainers = [{ name = "Martin Beroiz", email = "martinberoiz@gmail.com" }]
 readme = "README.md"
 dynamic = ["version"]
 requires-python = ">=3.7"
-dependencies = ["numpy>=1.17", "scipy>=0.15", "scikit-image", "sep"]
+dependencies = ["numpy>=1.17", "scipy>=0.15", "scikit-image", "sep-pjw"]
 license = { file = "LICENSE.txt" }
 keywords = [
     "astronomy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Astrometric Alignment of Images"
 maintainers = [{ name = "Martin Beroiz", email = "martinberoiz@gmail.com" }]
 readme = "README.md"
 dynamic = ["version"]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = ["numpy>=1.17", "scipy>=0.15", "scikit-image", "sep-pjw"]
 license = { file = "LICENSE.txt" }
 keywords = [

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -265,7 +265,7 @@ class TestAlign(unittest.TestCase):
         """Return the fraction of sources found in the reference image"""
         # pixel comparison is not good, doesn't work. Compare catalogs.
         full_algn = the_image.astype("float32")
-        import sep
+        import sep_pjw as sep
 
         bkg = sep.Background(full_algn)
         thresh = 5.0 * bkg.globalrms
@@ -724,7 +724,7 @@ class TestColorImages(unittest.TestCase):
         """Return the fraction of sources found in the reference image"""
         # pixel comparison is not good, doesn't work. Compare catalogs.
         full_algn = np.mean(the_image, axis=-1, dtype="float32")
-        import sep
+        import sep_pjw as sep
 
         bkg = sep.Background(full_algn)
         thresh = 5.0 * bkg.globalrms


### PR DESCRIPTION
As sep needs re-compiling for numpy > 2.0 ABI, it doesn't work anymore. The fork sep-pjw offers a good alternative.